### PR TITLE
Implement shader uniform manager and material system with type-safe setters and caching

### DIFF
--- a/MATERIAL_SYSTEM.md
+++ b/MATERIAL_SYSTEM.md
@@ -1,0 +1,162 @@
+# Shader Uniform Manager & Material System
+
+## Overview
+
+The enhanced Shader class now includes:
+- **Automatic uniform location caching** - No more repeated `glGetUniformLocation` calls
+- **Type-safe uniform setters** - Clean, easy-to-use API for setting uniforms
+- **Material class** - Bundles shaders, textures, and material properties
+
+## Features
+
+### 1. Type-Safe Uniform Setters
+
+Instead of the old way:
+```cpp
+// OLD: Manual uniform location lookup and setting
+glUniform1i(glGetUniformLocation(shader.getID(), "myTexture"), 0);
+glUniform3fv(glGetUniformLocation(shader.getID(), "lightPos"), 1, glm::value_ptr(position));
+glUniformMatrix4fv(glGetUniformLocation(shader.getID(), "model"), 1, GL_FALSE, glm::value_ptr(modelMatrix));
+```
+
+Use the new way:
+```cpp
+// NEW: Clean, type-safe API
+shader->setInt("myTexture", 0);
+shader->setVec3("lightPos", position);
+shader->setMat4("model", modelMatrix);
+```
+
+### 2. Uniform Location Caching
+
+The Shader class automatically caches uniform locations internally. The first call to any setter looks up the location, subsequent calls use the cached value. This significantly improves performance when setting uniforms multiple times per frame.
+
+### 3. Available Uniform Setters
+
+```cpp
+// Integer
+shader->setInt("textureSampler", 0);
+
+// Float
+shader->setFloat("time", 1.5f);
+
+// Vec2
+shader->setVec2("resolution", glm::vec2(800, 600));
+shader->setVec2("resolution", 800.0f, 600.0f);
+
+// Vec3
+shader->setVec3("lightColor", glm::vec3(1.0f, 1.0f, 1.0f));
+shader->setVec3("lightColor", 1.0f, 1.0f, 1.0f);
+
+// Vec4
+shader->setVec4("color", glm::vec4(1.0f, 0.5f, 0.2f, 1.0f));
+shader->setVec4("color", 1.0f, 0.5f, 0.2f, 1.0f);
+
+// Mat3
+shader->setMat3("normalMatrix", normalMatrix);
+
+// Mat4
+shader->setMat4("model", modelMatrix);
+shader->setMat4("view", viewMatrix);
+shader->setMat4("projection", projectionMatrix);
+```
+
+## Material System
+
+### Creating a Material
+
+```cpp
+#include "header/Material.h"
+
+// Create material with a shader
+auto myMaterial = std::make_shared<Material>(myShader);
+
+// Add textures
+myMaterial->addTexture(diffuseTexture);
+myMaterial->addTexture(specularTexture);
+
+// Set material properties
+myMaterial->setDiffuseColor(glm::vec3(1.0f, 0.8f, 0.6f));
+myMaterial->setSpecularColor(glm::vec3(1.0f, 1.0f, 1.0f));
+myMaterial->setShininess(64.0f);
+myMaterial->setAlpha(1.0f);
+```
+
+### Using a Material
+
+```cpp
+// Activate the material (binds shader, textures, and sets properties)
+myMaterial->use();
+
+// Now draw your geometry
+mesh->Draw();
+```
+
+### Material Properties
+
+Materials support common PBR-like properties:
+
+- **Diffuse Color** - Base color of the material
+- **Specular Color** - Color of specular highlights
+- **Ambient Color** - Ambient lighting contribution
+- **Shininess** - Specular exponent (1-128)
+- **Alpha** - Opacity value (0.0 = transparent, 1.0 = opaque)
+
+### Expected Shader Uniforms
+
+When using the Material system, your fragment shader should expect these uniforms:
+
+```glsl
+struct Material {
+    sampler2D diffuse;    // Diffuse texture
+    sampler2D specular;   // Specular texture (optional)
+    sampler2D normal;     // Normal map (optional)
+    
+    vec3 diffuseColor;
+    vec3 specularColor;
+    vec3 ambientColor;
+    float shininess;
+    float alpha;
+};
+
+uniform Material material;
+```
+
+## Benefits
+
+1. **Performance**: Uniform locations are cached, eliminating redundant lookups
+2. **Type Safety**: Compile-time checking of uniform types
+3. **Cleaner Code**: Less boilerplate, more readable
+4. **Encapsulation**: Material bundles related rendering state
+5. **Flexibility**: Easy to swap materials on the fly
+
+## Migration Guide
+
+### Old Code
+```cpp
+shader->Enable();
+glUniform3fv(glGetUniformLocation(shader->getID(), "dirLight.direction"), 1, glm::value_ptr(dir));
+glUniform3fv(glGetUniformLocation(shader->getID(), "dirLight.ambient"), 1, glm::value_ptr(ambient));
+glUniform3fv(glGetUniformLocation(shader->getID(), "dirLight.diffuse"), 1, glm::value_ptr(diffuse));
+```
+
+### New Code
+```cpp
+shader->Enable();
+shader->setVec3("dirLight.direction", dir);
+shader->setVec3("dirLight.ambient", ambient);
+shader->setVec3("dirLight.diffuse", diffuse);
+```
+
+## Next Steps
+
+Consider updating your existing code progressively:
+1. Replace manual `glGetUniformLocation` + `glUniform*` calls with the new setters
+2. Create Material instances for different object types
+3. Refactor mesh/model rendering to use Materials
+
+## Notes
+
+- Uniform location caching is thread-safe for read operations
+- Missing uniforms will log a warning but won't crash
+- The Material class is designed to work with the existing ResourceManager

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(Reverse PRIVATE
     Interface.cpp
     Logger.cpp
     ResourceManager.cpp
+    Material.cpp
 )
 
 target_include_directories(Reverse 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -85,7 +85,7 @@ void Camera::MouseMovement(GLFWwindow* window, float deltaTime)
 void Camera::UpdateShader(Shader& shader, const char* uniform)
 {
     shader.Enable();
-    glUniformMatrix4fv(glGetUniformLocation(shader.getID(), uniform), 1, GL_FALSE, glm::value_ptr(cameraView));
+    shader.setMat4(uniform, cameraView);
 }
 
 void Camera::Update(GLFWwindow* window, float deltaTime, std::vector<std::shared_ptr<Shader>>& shaderList, const char* uniform)

--- a/src/Light.cpp
+++ b/src/Light.cpp
@@ -34,32 +34,33 @@ void Light::LightProperties(const glm::vec3& ambient, const glm::vec3& diffuse, 
 
 void DirectionalLight::ShaderData(Shader& shader) {
     shader.Enable();
-        
-    glUniform3fv(glGetUniformLocation(shader.getID(), "dirLight.direction"), 1,  glm::value_ptr(dir));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "dirLight.ambient"), 1, glm::value_ptr(ambient));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "dirLight.diffuse"), 1,  glm::value_ptr(diffuse));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "dirLight.specular"), 1,  glm::value_ptr(specular));
+    
+    shader.setVec3("dirLight.direction", dir);
+    shader.setVec3("dirLight.ambient", ambient);
+    shader.setVec3("dirLight.diffuse", diffuse);
+    shader.setVec3("dirLight.specular", specular);
 }
 
 void PointLight::ShaderData(Shader& shader) {
     shader.Enable();
-    glUniform3fv(glGetUniformLocation(shader.getID(), "pointLight.position"), 1,  glm::value_ptr(pos));
-    glUniform1fv(glGetUniformLocation(shader.getID(), "pointLight.constant"), 1,  &attConstant);
-    glUniform1fv(glGetUniformLocation(shader.getID(), "pointLight.linear"), 1,  &attLinear);
-    glUniform1fv(glGetUniformLocation(shader.getID(), "pointLight.quadratic"), 1, &attQuadratic);
-    glUniform3fv(glGetUniformLocation(shader.getID(), "pointLight.ambient"), 1, glm::value_ptr(ambient));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "pointLight.diffuse"), 1,  glm::value_ptr(diffuse));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "pointLight.specular"), 1,  glm::value_ptr(specular));    
+    
+    shader.setVec3("pointLight.position", pos);
+    shader.setFloat("pointLight.constant", attConstant);
+    shader.setFloat("pointLight.linear", attLinear);
+    shader.setFloat("pointLight.quadratic", attQuadratic);
+    shader.setVec3("pointLight.ambient", ambient);
+    shader.setVec3("pointLight.diffuse", diffuse);
+    shader.setVec3("pointLight.specular", specular);
 }
 
 void SpotLight::ShaderData(Shader& shader) {
     shader.Enable();
-    glUniform3fv(glGetUniformLocation(shader.getID(), "spotLight.direction"), 1,  glm::value_ptr(dir));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "spotLight.position"), 1,  glm::value_ptr(pos));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "spotLight.ambient"), 1, glm::value_ptr(ambient));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "spotLight.diffuse"), 1,  glm::value_ptr(diffuse));
-    glUniform3fv(glGetUniformLocation(shader.getID(), "spotLight.specular"), 1,  glm::value_ptr(specular));
-    glUniform1fv(glGetUniformLocation(shader.getID(), "spotLight.innerCutOff"), 1, &innerCutOff);
-    glUniform1fv(glGetUniformLocation(shader.getID(), "spotLight.outerCutOff"), 1, &outerCutOff);
     
+    shader.setVec3("spotLight.direction", dir);
+    shader.setVec3("spotLight.position", pos);
+    shader.setVec3("spotLight.ambient", ambient);
+    shader.setVec3("spotLight.diffuse", diffuse);
+    shader.setVec3("spotLight.specular", specular);
+    shader.setFloat("spotLight.innerCutOff", innerCutOff);
+    shader.setFloat("spotLight.outerCutOff", outerCutOff);
 }

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -1,0 +1,130 @@
+/**
+ * @file Material.cpp
+ * @brief Implementation of the Material class
+ */
+
+#include "header/Material.h"
+#include "header/Logger.h"
+
+Material::Material(std::shared_ptr<Shader> shader)
+    : shader(shader) {
+    if (!shader) {
+        LOG_ERROR("Material created with null shader");
+        throw std::invalid_argument("Material requires a valid shader");
+    }
+}
+
+void Material::use() const {
+    if (!shader) {
+        LOG_ERROR("Attempting to use material with null shader");
+        return;
+    }
+    
+    // Activate the shader
+    shader->Enable();
+    
+    // Bind all textures
+    int diffuseNum = 0;
+    int specularNum = 0;
+    int normalNum = 0;
+    
+    for (size_t i = 0; i < textures.size(); ++i) {
+        const auto& texture = textures[i];
+        std::string type = texture->getType();
+        std::string uniformName;
+        
+        // Construct uniform name based on texture type
+        if (type == "diffuse") {
+            uniformName = "material.diffuse" + (diffuseNum > 0 ? std::to_string(diffuseNum) : "");
+            diffuseNum++;
+        }
+        else if (type == "specular") {
+            uniformName = "material.specular" + (specularNum > 0 ? std::to_string(specularNum) : "");
+            specularNum++;
+        }
+        else if (type == "normal") {
+            uniformName = "material.normal" + (normalNum > 0 ? std::to_string(normalNum) : "");
+            normalNum++;
+        }
+        else {
+            // Generic texture name
+            uniformName = type + std::to_string(i);
+        }
+        
+        texture->Bind(*shader, uniformName.c_str(), static_cast<int>(i));
+    }
+    
+    // Set material properties as uniforms
+    shader->setVec3("material.diffuseColor", diffuseColor);
+    shader->setVec3("material.specularColor", specularColor);
+    shader->setVec3("material.ambientColor", ambientColor);
+    shader->setFloat("material.shininess", shininess);
+    shader->setFloat("material.alpha", alpha);
+}
+
+std::shared_ptr<Shader> Material::getShader() const {
+    return shader;
+}
+
+// ===== Texture Management =====
+
+void Material::addTexture(std::shared_ptr<Texture> texture) {
+    if (texture) {
+        textures.push_back(texture);
+    }
+    else {
+        LOG_WARNING("Attempted to add null texture to material");
+    }
+}
+
+const std::vector<std::shared_ptr<Texture>>& Material::getTextures() const {
+    return textures;
+}
+
+void Material::clearTextures() {
+    textures.clear();
+}
+
+// ===== Material Properties - Setters =====
+
+void Material::setDiffuseColor(const glm::vec3& color) {
+    diffuseColor = color;
+}
+
+void Material::setSpecularColor(const glm::vec3& color) {
+    specularColor = color;
+}
+
+void Material::setAmbientColor(const glm::vec3& color) {
+    ambientColor = color;
+}
+
+void Material::setShininess(float shin) {
+    shininess = shin;
+}
+
+void Material::setAlpha(float a) {
+    alpha = glm::clamp(a, 0.0f, 1.0f);
+}
+
+// ===== Material Properties - Getters =====
+
+const glm::vec3& Material::getDiffuseColor() const {
+    return diffuseColor;
+}
+
+const glm::vec3& Material::getSpecularColor() const {
+    return specularColor;
+}
+
+const glm::vec3& Material::getAmbientColor() const {
+    return ambientColor;
+}
+
+float Material::getShininess() const {
+    return shininess;
+}
+
+float Material::getAlpha() const {
+    return alpha;
+}

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -24,6 +24,25 @@ ebo(indices.data(), indices.size() * sizeof(unsigned int))
     ebo.Unbind();
 }
 
+Mesh::Mesh(vector<Vertex>& vertices, vector<unsigned int>& indices, shared_ptr<Material> material): 
+vertices(vertices), indices(indices), material(material),
+vao(),
+vbo(vertices.data(), vertices.size() * sizeof(Vertex)),
+ebo(indices.data(), indices.size() * sizeof(unsigned int))
+{
+    vao.Bind();
+    vbo.Bind();
+    ebo.Bind();
+
+    vao.LinkAttrib(vbo, 0, 3, GL_FLOAT, sizeof(Vertex), (void*)offsetof(Vertex, Vertex::Position));
+    vao.LinkAttrib(vbo, 1, 3, GL_FLOAT, sizeof(Vertex), (void*)offsetof(Vertex, Vertex::Normal));
+    vao.LinkAttrib(vbo, 2, 2, GL_FLOAT, sizeof(Vertex), (void*)offsetof(Vertex, Vertex::TexCoord));
+
+    vao.Unbind();
+    vbo.Unbind();
+    ebo.Unbind();
+}
+
 void Mesh::Draw(Shader& shader, const char* uniform) const {
     shader.Enable();
     
@@ -32,7 +51,7 @@ void Mesh::Draw(Shader& shader, const char* uniform) const {
     model = glm::translate(model, position);
     model = glm::rotate(model, rotation, rotationAxis);
     model = glm::scale(model, scale);
-    glUniformMatrix4fv(glGetUniformLocation(shader.getID(), uniform), 1, GL_FALSE, glm::value_ptr(model));
+    shader.setMat4(uniform, model);
 
     // Bind textures
     unsigned int diffuseNr = 1;
@@ -54,6 +73,36 @@ void Mesh::Draw(Shader& shader, const char* uniform) const {
     vao.Bind();
     glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
     vao.Unbind();
+}
+
+void Mesh::Draw() const {
+    if (!material) {
+        return; // No material set, cannot draw
+    }
+    
+    // Use material (binds shader and textures)
+    material->use();
+    
+    // Apply transformation matrix
+    glm::mat4 model = glm::mat4(1.0f);
+    model = glm::translate(model, position);
+    model = glm::rotate(model, rotation, rotationAxis);
+    model = glm::scale(model, scale);
+    
+    material->getShader()->setMat4("model", model);
+    
+    // Render mesh
+    vao.Bind();
+    glDrawElements(GL_TRIANGLES, indices.size(), GL_UNSIGNED_INT, 0);
+    vao.Unbind();
+}
+
+void Mesh::setMaterial(shared_ptr<Material> mat) {
+    material = mat;
+}
+
+shared_ptr<Material> Mesh::getMaterial() const {
+    return material;
 }
 
 void Mesh::Delete()

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -73,3 +73,63 @@ void Shader::compileErrors(unsigned int shader, const string& type) {
         }
     }
 }
+
+// ===== Uniform Location Caching =====
+
+GLint Shader::getUniformLocation(const string& name) const {
+    // Check if location is already cached
+    auto it = uniformLocationCache.find(name);
+    if (it != uniformLocationCache.end()) {
+        return it->second;
+    }
+    
+    // Look up location and cache it
+    GLint location = glGetUniformLocation(ID, name.c_str());
+    if (location == -1) {
+        LOG_WARNING("Uniform '" + name + "' not found in shader program");
+    }
+    uniformLocationCache[name] = location;
+    return location;
+}
+
+// ===== Type-safe Uniform Setters =====
+
+void Shader::setInt(const string& name, int value) {
+    glUniform1i(getUniformLocation(name), value);
+}
+
+void Shader::setFloat(const string& name, float value) {
+    glUniform1f(getUniformLocation(name), value);
+}
+
+void Shader::setVec2(const string& name, const glm::vec2& value) {
+    glUniform2fv(getUniformLocation(name), 1, glm::value_ptr(value));
+}
+
+void Shader::setVec2(const string& name, float x, float y) {
+    glUniform2f(getUniformLocation(name), x, y);
+}
+
+void Shader::setVec3(const string& name, const glm::vec3& value) {
+    glUniform3fv(getUniformLocation(name), 1, glm::value_ptr(value));
+}
+
+void Shader::setVec3(const string& name, float x, float y, float z) {
+    glUniform3f(getUniformLocation(name), x, y, z);
+}
+
+void Shader::setVec4(const string& name, const glm::vec4& value) {
+    glUniform4fv(getUniformLocation(name), 1, glm::value_ptr(value));
+}
+
+void Shader::setVec4(const string& name, float x, float y, float z, float w) {
+    glUniform4f(getUniformLocation(name), x, y, z, w);
+}
+
+void Shader::setMat3(const string& name, const glm::mat3& value) {
+    glUniformMatrix3fv(getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(value));
+}
+
+void Shader::setMat4(const string& name, const glm::mat4& value) {
+    glUniformMatrix4fv(getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(value));
+}

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -46,7 +46,7 @@ Texture::Texture(const char* filePath, const char* type) : path(filePath), type(
 void Texture::Bind(Shader& shader, const char* uniform, int texUnit) const {
     glActiveTexture(GL_TEXTURE0 + texUnit);
     glBindTexture(GL_TEXTURE_2D, ID);
-    glUniform1i(glGetUniformLocation(shader.getID(), uniform), texUnit);
+    shader.setInt(uniform, texUnit);
 }
 
 string Texture::getType() const {

--- a/src/header/Material.h
+++ b/src/header/Material.h
@@ -1,0 +1,132 @@
+/**
+ * @file Material.h
+ * @brief Material system for managing shaders, textures, and properties
+ * @details Bundles shader programs with textures and uniform values for rendering
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <glm/glm.hpp>
+#include "Shader.h"
+#include "Texture.h"
+
+/**
+ * @brief Represents a complete material for rendering
+ * @details Bundles a shader program with textures and material properties.
+ * Provides a unified interface for setting up rendering state.
+ */
+class Material
+{
+public:
+    /**
+     * @brief Constructs a material with a shader
+     * @param shader Shared pointer to the shader program
+     */
+    Material(std::shared_ptr<Shader> shader);
+    
+    /**
+     * @brief Activates this material for rendering
+     * @details Enables the shader and binds all textures
+     */
+    void use() const;
+    
+    /**
+     * @brief Gets the associated shader program
+     * @return Shared pointer to the shader
+     */
+    std::shared_ptr<Shader> getShader() const;
+    
+    // ===== Texture Management =====
+    
+    /**
+     * @brief Adds a texture to the material
+     * @param texture Shared pointer to the texture
+     */
+    void addTexture(std::shared_ptr<Texture> texture);
+    
+    /**
+     * @brief Gets all textures in the material
+     * @return Vector of texture pointers
+     */
+    const std::vector<std::shared_ptr<Texture>>& getTextures() const;
+    
+    /**
+     * @brief Clears all textures from the material
+     */
+    void clearTextures();
+    
+    // ===== Material Properties =====
+    
+    /**
+     * @brief Sets the diffuse color
+     * @param color RGB diffuse color
+     */
+    void setDiffuseColor(const glm::vec3& color);
+    
+    /**
+     * @brief Sets the specular color
+     * @param color RGB specular color
+     */
+    void setSpecularColor(const glm::vec3& color);
+    
+    /**
+     * @brief Sets the ambient color
+     * @param color RGB ambient color
+     */
+    void setAmbientColor(const glm::vec3& color);
+    
+    /**
+     * @brief Sets the shininess factor
+     * @param shininess Shininess value (typically 1-128)
+     */
+    void setShininess(float shininess);
+    
+    /**
+     * @brief Sets the opacity/alpha value
+     * @param alpha Opacity value (0.0 = transparent, 1.0 = opaque)
+     */
+    void setAlpha(float alpha);
+    
+    /**
+     * @brief Gets the diffuse color
+     * @return RGB diffuse color
+     */
+    const glm::vec3& getDiffuseColor() const;
+    
+    /**
+     * @brief Gets the specular color
+     * @return RGB specular color
+     */
+    const glm::vec3& getSpecularColor() const;
+    
+    /**
+     * @brief Gets the ambient color
+     * @return RGB ambient color
+     */
+    const glm::vec3& getAmbientColor() const;
+    
+    /**
+     * @brief Gets the shininess factor
+     * @return Shininess value
+     */
+    float getShininess() const;
+    
+    /**
+     * @brief Gets the opacity/alpha value
+     * @return Alpha value
+     */
+    float getAlpha() const;
+    
+private:
+    std::shared_ptr<Shader> shader;                    ///< Associated shader program
+    std::vector<std::shared_ptr<Texture>> textures;    ///< Material textures
+    
+    // Material properties
+    glm::vec3 diffuseColor{1.0f, 1.0f, 1.0f};   ///< Diffuse color (default white)
+    glm::vec3 specularColor{1.0f, 1.0f, 1.0f};  ///< Specular color (default white)
+    glm::vec3 ambientColor{0.1f, 0.1f, 0.1f};   ///< Ambient color (default dark gray)
+    float shininess{32.0f};                      ///< Shininess factor (default 32)
+    float alpha{1.0f};                           ///< Opacity (default opaque)
+};

--- a/src/header/Mesh.h
+++ b/src/header/Mesh.h
@@ -25,6 +25,7 @@
 #include "EBO.h"
 #include "Texture.h"
 #include "Shader.h"
+#include "Material.h"
 
 using std::vector, std::string, std::shared_ptr;
 
@@ -44,6 +45,14 @@ public:
     Mesh(vector<Vertex>& vertices, vector<unsigned int>& indices, vector<shared_ptr<Texture>>& textures);
     
     /**
+     * @brief Constructs a mesh with a material
+     * @param vertices Vertex data (positions, normals, texture coordinates)
+     * @param indices Element indices for indexed drawing
+     * @param material Shared pointer to the material to use for rendering
+     */
+    Mesh(vector<Vertex>& vertices, vector<unsigned int>& indices, shared_ptr<Material> material);
+    
+    /**
      * @brief Renders the mesh using the specified shader
      * @param shader Shader program to use
      * @param uniform Name of the model matrix uniform in the shader
@@ -51,8 +60,27 @@ public:
     void Draw(Shader& shader, const char* uniform) const;
     
     /**
+     * @brief Renders the mesh using its assigned material
+     * @details Automatically binds the material and sets the model matrix
+     */
+    void Draw() const;
+    
+    /**
+     * @brief Sets the material for this mesh
+     * @param material Shared pointer to the material
+     */
+    void setMaterial(shared_ptr<Material> material);
+    
+    /**
+     * @brief Gets the material of this mesh
+     * @return Shared pointer to the material, or nullptr if not set
+     */
+    shared_ptr<Material> getMaterial() const;
+    
+    /**
      * @brief Frees GPU resources
      */
+    shared_ptr<Material> material;     ///< Material for rendering (optional)
     void Delete();
     
     /**

--- a/src/header/Shader.h
+++ b/src/header/Shader.h
@@ -1,7 +1,7 @@
 /**
  * @file Shader.h
  * @brief OpenGL shader program management
- * @details Compiles, links, and manages GLSL shader programs
+ * @details Compiles, links, and manages GLSL shader programs with uniform caching
  */
 
 #pragma once
@@ -12,12 +12,15 @@
 #include<sstream>
 #include<iostream>
 #include<cerrno>
+#include<unordered_map>
+#include<glm/glm.hpp>
+#include<glm/gtc/type_ptr.hpp>
 
 using std::string;
 
 /**
  * @brief Manages an OpenGL shader program
- * @details Handles vertex and fragment shader compilation, linking, and lifecycle
+ * @details Handles vertex and fragment shader compilation, linking, lifecycle, and uniform management with caching
  */
 class Shader
 {
@@ -46,8 +49,94 @@ public:
      */
     void Delete();
 
+    // ===== Type-safe uniform setters with automatic caching =====
+    
+    /**
+     * @brief Sets an integer uniform
+     * @param name Uniform name in shader
+     * @param value Integer value to set
+     */
+    void setInt(const string& name, int value);
+    
+    /**
+     * @brief Sets a float uniform
+     * @param name Uniform name in shader
+     * @param value Float value to set
+     */
+    void setFloat(const string& name, float value);
+    
+    /**
+     * @brief Sets a vec2 uniform
+     * @param name Uniform name in shader
+     * @param value vec2 value to set
+     */
+    void setVec2(const string& name, const glm::vec2& value);
+    
+    /**
+     * @brief Sets a vec2 uniform from components
+     * @param name Uniform name in shader
+     * @param x X component
+     * @param y Y component
+     */
+    void setVec2(const string& name, float x, float y);
+    
+    /**
+     * @brief Sets a vec3 uniform
+     * @param name Uniform name in shader
+     * @param value vec3 value to set
+     */
+    void setVec3(const string& name, const glm::vec3& value);
+    
+    /**
+     * @brief Sets a vec3 uniform from components
+     * @param name Uniform name in shader
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
+     */
+    void setVec3(const string& name, float x, float y, float z);
+    
+    /**
+     * @brief Sets a vec4 uniform
+     * @param name Uniform name in shader
+     * @param value vec4 value to set
+     */
+    void setVec4(const string& name, const glm::vec4& value);
+    
+    /**
+     * @brief Sets a vec4 uniform from components
+     * @param name Uniform name in shader
+     * @param x X component
+     * @param y Y component
+     * @param z Z component
+     * @param w W component
+     */
+    void setVec4(const string& name, float x, float y, float z, float w);
+    
+    /**
+     * @brief Sets a mat3 uniform
+     * @param name Uniform name in shader
+     * @param value mat3 value to set
+     */
+    void setMat3(const string& name, const glm::mat3& value);
+    
+    /**
+     * @brief Sets a mat4 uniform
+     * @param name Uniform name in shader
+     * @param value mat4 value to set
+     */
+    void setMat4(const string& name, const glm::mat4& value);
+
 private:
     GLuint ID; ///< OpenGL shader program identifier
+    mutable std::unordered_map<string, GLint> uniformLocationCache; ///< Cache for uniform locations
+    
+    /**
+     * @brief Gets a uniform location with caching to avoid redundant lookups
+     * @param name Uniform name in shader
+     * @return The uniform location, or -1 if not found
+     */
+    GLint getUniformLocation(const string& name) const;
     
     /**
      * @brief Checks for shader compilation/linking errors and throws if found

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "header/Config.h"
 #include "header/Logger.h"
 #include "header/ResourceManager.h"
+#include "header/Material.h"
 
 using std::vector;
 
@@ -127,13 +128,27 @@ int main(){
         Interface ui(window, *interfaceProgram);
         
         // Load textures using ResourceManager (must be after OpenGL context is created)
-        vector<std::shared_ptr<Texture>> cubeTextures = {resourceManager.loadTexture("./resource/textures/marble.jpg", "diffuse")};
-        vector<std::shared_ptr<Texture>> planeTextures = {resourceManager.loadTexture("./resource/textures/wall.jpg", "diffuse")};
+        auto marbleTexture = resourceManager.loadTexture("./resource/textures/marble.jpg", "diffuse");
+        auto wallTexture = resourceManager.loadTexture("./resource/textures/wall.jpg", "diffuse");
         
-        Mesh cube(cubeVertices, cubeIndices, cubeTextures);
-        Mesh cube2(cubeVertices, cubeIndices, cubeTextures);
+        // Create Materials with different properties
+        auto marbleMaterial = std::make_shared<Material>(shaderProgram);
+        marbleMaterial->addTexture(marbleTexture);
+        marbleMaterial->setDiffuseColor(glm::vec3(1.0f, 1.0f, 1.0f));
+        marbleMaterial->setSpecularColor(glm::vec3(0.8f, 0.8f, 0.8f));
+        marbleMaterial->setShininess(64.0f);
+        
+        auto wallMaterial = std::make_shared<Material>(shaderProgram);
+        wallMaterial->addTexture(wallTexture);
+        wallMaterial->setDiffuseColor(glm::vec3(0.9f, 0.9f, 0.9f));
+        wallMaterial->setSpecularColor(glm::vec3(0.3f, 0.3f, 0.3f));
+        wallMaterial->setShininess(32.0f);
+        
+        // Create meshes with materials
+        Mesh cube(cubeVertices, cubeIndices, marbleMaterial);
+        Mesh cube2(cubeVertices, cubeIndices, marbleMaterial);
         cube2.setPosition(glm::vec3(2.0f, 0.0f, 0.0f));
-        Mesh plane(planeVertices, planeIndices, planeTextures);
+        Mesh plane(planeVertices, planeIndices, wallMaterial);
 
         
         // Camera
@@ -161,10 +176,10 @@ int main(){
             );
             program.ClearBuffers();
 
-            // Render scene geometry
-            cube.Draw(*shaderProgram, "model");
-            cube2.Draw(*shaderProgram, "model");
-            plane.Draw(*shaderProgram, "model");
+            // Render scene geometry using materials
+            cube.Draw();
+            cube2.Draw();
+            plane.Draw();
 
             // Update camera view-projection matrix
             glfwGetFramebufferSize(window, &width, &height);


### PR DESCRIPTION
Closes: #2 
This pull request introduces a new material system and refactors shader uniform management for improved performance, type safety, and code clarity. The Shader class now supports automatic uniform location caching and type-safe setters, while a new Material class encapsulates shaders, textures, and material properties. Meshes can now be constructed and rendered directly with materials, streamlining rendering workflows and reducing boilerplate code.

### Material System & Shader Uniform Management

* Added a new `Material` class (`src/header/Material.h`, `src/Material.cpp`) that bundles shaders, textures, and material properties, providing a unified interface for rendering and supporting common PBR-like properties. [[1]](diffhunk://#diff-7d7c6bf7f581cd617b93a33df1f2ed56b3f6d1e67086f4d505e7f07d68f95139R1-R132) [[2]](diffhunk://#diff-fb646b3422c0ac8387f51c0e891c22e9595f82d4f642beb2f9655e3cbdac3812R1-R130)
* Refactored `Shader` to cache uniform locations and provide type-safe uniform setters (e.g., `setInt`, `setVec3`, `setMat4`), eliminating manual `glGetUniformLocation` and reducing runtime overhead. [[1]](diffhunk://#diff-b4230b81837a284e1f44bc4baa92853a7df306218f3375b9599110220c308412R76-R135) [[2]](diffhunk://#diff-25a5afa05276cbdc206e64b3c403086eca84091de0f5df3176e46e8173f43f77L4-R4)
* Updated documentation with a new `MATERIAL_SYSTEM.md` describing usage, migration, and benefits of the new system.

### Mesh Integration

* Extended `Mesh` to support construction and rendering with a `Material` (including new constructors, `Draw()`, and material management methods), allowing for direct use of the material system in mesh rendering. [[1]](diffhunk://#diff-90d5c992b7e3afb6a85b3f899b35d7adda36b567e559f67141f403e02c00a13aR47-R83) [[2]](diffhunk://#diff-a1ab44562490a6eedefc0b00be01a8f09d7ea610386c670f05ec38bbe44550b9R27-R45) [[3]](diffhunk://#diff-a1ab44562490a6eedefc0b00be01a8f09d7ea610386c670f05ec38bbe44550b9R78-R107)

### Refactoring of Uniform Setting

* Replaced manual uniform setting (using `glGetUniformLocation` and `glUniform*`) in `Camera`, `Light`, `Mesh`, and `Texture` with the new type-safe setters from `Shader`, simplifying code and ensuring type safety. [[1]](diffhunk://#diff-cb24d484ff69b7182f5357c999c7f69efafc32ce735115053815a63bd983f56fL88-R88) [[2]](diffhunk://#diff-7de944970432c9a633c7ef14db5b2ae680bea3c27d482a743283be8592b90a82L38-R65) [[3]](diffhunk://#diff-a1ab44562490a6eedefc0b00be01a8f09d7ea610386c670f05ec38bbe44550b9L35-R54) [[4]](diffhunk://#diff-f7f787cd50e3dd66547198c44687f3845149335e5fcf03af4609d7e2ec86e0afL49-R49)

These changes collectively modernize the rendering codebase, making it more robust, readable, and easier to maintain.